### PR TITLE
stop commitlint check on main

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -3,6 +3,7 @@ name: Lint Commit Messages
 on:
   pull_request:
   push:
+    branches-ignore: [main]
 
 jobs:
   commitlint:


### PR DESCRIPTION
it clashes with dependabot-triggered commits and we don't want to run this check on them